### PR TITLE
Transcribe content as a whole and as chunks

### DIFF
--- a/bin/lib/extract-audio.js
+++ b/bin/lib/extract-audio.js
@@ -42,7 +42,9 @@ module.exports = function(sourceFilePath, jobID){
 							const process = spawn(ffmpeg.path, args);
 							
 							process.stdout.on('data', (data) => {
-								debug(`stdout: ${data}`);
+								if(process.env.VERBOSE_FFMPEG){
+									debug(`stdout: ${data}`);
+								}
 							});
 
 							process.stderr.on('data', (data) => {

--- a/bin/lib/split-audio.js
+++ b/bin/lib/split-audio.js
@@ -33,7 +33,9 @@ module.exports = function(sourceFilePath, jobID){
 			const process = spawn(ffmpeg.path, args);
 			
 			process.stdout.on('data', (data) => {
-				debug(`stdout: ${data}`);
+				if(process.env.VERBOSE_FFMPEG){
+					debug(`stdout: ${data}`);
+				}
 			});
 
 			process.stderr.on('data', (data) => {

--- a/bin/lib/split-audio.js
+++ b/bin/lib/split-audio.js
@@ -7,7 +7,7 @@ const shortID = require('shortid').generate;
 const tmpPath = process.env.TMP_PATH || '/tmp';
 
 // ffmpeg -i somefile.mp3 -f segment -segment_time 3 -c copy out%03d.mp3
-module.exports = function(sourceFilePath, jobID){
+module.exports = function(sourceFilePath, jobID, duration = 3){
 
 	return new Promise( (resolve, reject) => {
 
@@ -24,7 +24,7 @@ module.exports = function(sourceFilePath, jobID){
 				'-f',
 				'segment',
 				'-segment_time',
-				'3',
+				duration,
 				'-c',
 				'copy',
 				`${splitFilesDestination}/out%03d.wav`

--- a/bin/lib/transcribe-audio.js
+++ b/bin/lib/transcribe-audio.js
@@ -12,12 +12,13 @@ const Speech = gcloud.speech;
 
 const speech = new Speech({
 	projectId,
-	credentials: JSON.parse(process.env.GCLOUD_CREDS)
+	credentials: JSON.parse(process.env.GCLOUD_CREDS),
+	deadline : 50000
 });
 
 const wait = (time) => {return new Promise( resolve => { setTimeout(resolve, time) } ) };
 
-function splitPhrases(phrase, chunkSize = 100, respectSpaces = true){
+function splitPhrases(phrase = "", chunkSize = 100, respectSpaces = true){
 
 	const words = phrase.split(' ');
 

--- a/bin/lib/transcribe-audio.js
+++ b/bin/lib/transcribe-audio.js
@@ -60,7 +60,7 @@ function transcribeAudio(audioFile, phrase = ''){
 			verbose: true
 		};
 
-		speech.asyncrecognize(audioFile, config, function(err, result) {
+		speech.recognize(audioFile, config, function(err, result) {
 				
 				if(err){
 					reject(err);
@@ -83,9 +83,10 @@ module.exports = function(audioFiles, phrase){
 	if(audioFiles.constructor !== Array){
 		audioFiles = [audioFiles];
 	}
-	
+	console.time('transcribe');
 	return Promise.all( audioFiles.map(file => { return transcribeAudio(file, phrase) } ) )
 		.then(transcriptions => {
+			console.time('transcribe');
 			if(transcriptions.length === 1){
 				return transcriptions[0];
 			} else {

--- a/bin/lib/transcribe-audio.js
+++ b/bin/lib/transcribe-audio.js
@@ -8,60 +8,130 @@ const gcloud = require('google-cloud')({
 	credentials: JSON.parse(process.env.GCLOUD_CREDS)
 });
 
-const speech = gcloud.speech;
+const Speech = gcloud.speech;
 
-const speechClient = speech({
+const speech = new Speech({
 	projectId,
 	credentials: JSON.parse(process.env.GCLOUD_CREDS)
 });
 
 const wait = (time) => {return new Promise( resolve => { setTimeout(resolve, time) } ) };
 
-function transcribeAudioFile(filePath, attempt = 0){
+function splitPhrases(phrase, chunkSize = 100, respectSpaces = true){
 
-	return new Promise( (resolve, reject) => {
+	const words = phrase.split(' ');
 
-		speechClient.recognize(filePath, {
-			encoding: 'LINEAR16',
-			sampleRate: 16000
-			}, function(err, transcript) {
-				
-				if(err){
+	const chunks = [];
 
-					if(err.description === 'Secure read failed'){
-						if(attempt < 3){
+	let currentChunk = "";
 
-							wait(800 * (attempt + 1))
-								.then(function(){
-									transcribeAudioFile(filePath, attempt += 1)
-										.then(transcription => {
-											resolve(transcription);
-										})
-									;
-								})
-							;
+	debug(words, chunks, currentChunk);
 
-						} else {
-							reject(err);
-						}
+	words.forEach(word => {
 
-					} else {
-						reject(err);
-					}
+		if(`${currentChunk} `.length + word.length < chunkSize){
+			currentChunk = `${currentChunk} ${word}`;
+		} else {
+			chunks.push(currentChunk);
+			currentChunk =` ${word}`;
+		}
+		
+		debug(words, chunks, currentChunk);
 
-				} else {
-					resolve(transcript);
-				}
+	});
 
-			}
-		);
-
-	} );
-	
+	return chunks;
 
 }
 
-module.exports = function(audioFiles){
+function transcribeAudio(audio, phrase = ''){
+
+	return new Promise( (resolve, reject) => {
+
+		debug('beginning transcribe');
+
+		const results = [];
+
+		let idx = 0;
+		const streams = audio.map(file => {return fs.createReadStream(file, {autoClose : false})});
+
+		const phrases = splitPhrases(phrase);
+
+		debug("PHRASING:", phrases);
+
+		const request = {
+			config: {
+				encoding: 'LINEAR16',
+				sampleRate: 16000,
+				profanityFilter : true,
+				speechContext : {
+					phrases
+				}
+			},
+			singleUtterance: false,
+			interimResults: false,
+			verbose: true
+		};
+
+		function transcribeAudioStream(stream){
+			debug(stream);
+			const S = speech.createRecognizeStream(request);
+
+			let u = "";
+
+			S.on('error', function(err){
+				debug('ERR', err);
+				reject(err);
+			});
+
+			S.on('data', function(d){
+				console.log(d);
+				// u = d.results;
+
+				if(d.results.forEach === undefined){
+					u += d.results;
+				} else {
+					let maxConfidence = 0;
+					let maxConfidencePhrase = '';
+
+					d.results.forEach(result => {
+						if(result.confidence > maxConfidence){
+							maxConfidence = result.confidence;
+							maxConfidencePhrase = result.transcript;
+						}
+					});
+
+					u += maxConfidencePhrase;
+
+				}
+
+			})
+
+			S.on('end', function(d){
+				debug(`Stream ${idx} ended`, d);
+				idx += 1;
+				// total += " " + u;
+				results.push(u)
+				if(idx < streams.length){
+					transcribeAudioStream(streams[idx]);
+				} else {
+					debug(u);
+					resolve(results);
+				}
+
+			});
+
+			stream.pipe(S);
+
+		};
+
+		transcribeAudioStream(streams[0]);
+
+	});
+
+}
+
+module.exports = function(audioFiles, phrase){
 
 	debug("audioFiles", audioFiles);
 
@@ -69,12 +139,6 @@ module.exports = function(audioFiles){
 		audioFiles = [audioFiles];
 	}
 	
-	return Promise.all( audioFiles.map(file => { return transcribeAudioFile(file) } ) )
-		.catch(err => {
-			debug(err);
-			throw Error('An error occurred in the transcription process');
-		})
-	;
-
+	return transcribeAudio(audioFiles, phrase);
 
 };

--- a/bin/lib/transcribe-audio.js
+++ b/bin/lib/transcribe-audio.js
@@ -20,6 +20,7 @@ const wait = (time) => {return new Promise( resolve => { setTimeout(resolve, tim
 
 function splitPhrases(phrase = "", chunkSize = 100, respectSpaces = true){
 
+	debug('PASSED PHRASE', phrase);
 	const words = phrase.split(' ');
 
 	const chunks = [];
@@ -45,90 +46,34 @@ function splitPhrases(phrase = "", chunkSize = 100, respectSpaces = true){
 
 }
 
-function transcribeAudio(audio, phrase = ''){
+function transcribeAudio(audioFile, phrase = ''){
 
 	return new Promise( (resolve, reject) => {
-
-		debug('beginning transcribe');
-
-		const results = [];
-
-		let idx = 0;
-		const streams = audio.map(file => {return fs.createReadStream(file, {autoClose : false})});
-
+		debug('PROMISE PHRASES', phrase);
 		const phrases = splitPhrases(phrase);
-
-		debug("PHRASING:", phrases);
-
-		const request = {
-			config: {
-				encoding: 'LINEAR16',
-				sampleRate: 16000,
-				profanityFilter : true,
-				speechContext : {
-					phrases
-				}
+		const config = {
+			encoding: 'LINEAR16',
+			sampleRate: 16000,
+			profanityFilter : true,
+			speechContext : {
+				phrases
 			},
-			singleUtterance: false,
-			interimResults: false,
 			verbose: true
 		};
 
-		function transcribeAudioStream(stream){
-			debug(stream);
-			const S = speech.createRecognizeStream(request);
-
-			let u = "";
-
-			S.on('error', function(err){
-				debug('ERR', err);
-				reject(err);
-			});
-
-			S.on('data', function(d){
-				console.log(d);
-				// u = d.results;
-
-				if(d.results.forEach === undefined){
-					u += d.results;
+		speech.recognize(audioFile, config, function(err, result) {
+				
+				if(err){
+					reject('>>> transcribe error:', err);
 				} else {
-					let maxConfidence = 0;
-					let maxConfidencePhrase = '';
-
-					d.results.forEach(result => {
-						if(result.confidence > maxConfidence){
-							maxConfidence = result.confidence;
-							maxConfidencePhrase = result.transcript;
-						}
-					});
-
-					u += maxConfidencePhrase;
-
+					debug('>>> result:', result);
+					resolve(result[0].transcript);
 				}
 
-			})
+			}
+		);
 
-			S.on('end', function(d){
-				debug(`Stream ${idx} ended`, d);
-				idx += 1;
-				// total += " " + u;
-				results.push(u)
-				if(idx < streams.length){
-					transcribeAudioStream(streams[idx]);
-				} else {
-					debug(u);
-					resolve(results);
-				}
-
-			});
-
-			stream.pipe(S);
-
-		};
-
-		transcribeAudioStream(streams[0]);
-
-	});
+	} );
 
 }
 
@@ -140,6 +85,19 @@ module.exports = function(audioFiles, phrase){
 		audioFiles = [audioFiles];
 	}
 	
-	return transcribeAudio(audioFiles, phrase);
+	return Promise.all( audioFiles.map(file => { return transcribeAudio(file, phrase) } ) )
+	.then(transcriptions => {
+		if(transcriptions.length === 1){
+			return transcriptions[0];
+		} else {
+			return transcriptions;
+		}
+	})
+		.catch(err => {
+			debug(err);
+			throw Error('An error occurred in the transcription process');
+		})
+	;
+
 
 };

--- a/bin/lib/wait.js
+++ b/bin/lib/wait.js
@@ -1,0 +1,1 @@
+module.exports = (time) => {return new Promise( resolve => { setTimeout(resolve, time) } ) };

--- a/routes/transcribe.js
+++ b/routes/transcribe.js
@@ -40,7 +40,7 @@ function generateTranscriptions(audioFile, req, res){
 
 		})
 		.then(data => {
-			return transcribeAudio(data.files, jobID)
+			return transcribeAudio(data.files)
 				.then(transcriptions => {
 					return transcriptions.map( (t, idx) => {
 						return {

--- a/routes/transcribe.js
+++ b/routes/transcribe.js
@@ -30,7 +30,7 @@ function generateTranscriptions(audioFile, req, res){
 	extractAudio(audioFile, jobID)
 		.then(audio => transcribeAudio(audio))
 		.then(transcription => {
-			
+			debug('\n\n\n\n\n', transcription);
 			return prepareAudio(audioFile, jobID)
 				.then(files => {
 					return getTimeIndexes(files)
@@ -44,6 +44,7 @@ function generateTranscriptions(audioFile, req, res){
 
 				})
 				.then(data => {
+					debug('+++++++ ', transcription);
 					return transcribeAudio(data.files, transcription)
 						.then(transcriptions => {
 							return transcriptions.map( (t, idx) => {


### PR DESCRIPTION
Transcribe the passed content in it's entirety and use that transcription to build the `phrases` parameter of the requests to transcribe the smaller audio chunks. This should result in better transcription results for the smaller chunks.